### PR TITLE
Update to 1.19.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.elsevier.MendeleyDesktop.appdata.xml
+++ b/com.elsevier.MendeleyDesktop.appdata.xml
@@ -22,6 +22,7 @@
     </screenshot>
   </screenshots>
   <releases>
+		<release version="1.19.2" date="2018-08-13"/>
 		<release version="1.19.1" date="2018-07-04"/>
 		<release version="1.17.13" date="2017-12-19"/>
   </releases>

--- a/com.elsevier.MendeleyDesktop.appdata.xml
+++ b/com.elsevier.MendeleyDesktop.appdata.xml
@@ -21,6 +21,10 @@
       <image>http://static.blog.mendeley.com/wp-content/uploads/2012/06/1.6-dev2-mac.png</image>
     </screenshot>
   </screenshots>
+  <releases>
+		<release version="1.19.1" date="2018-07-04"/>
+		<release version="1.17.13" date="2017-12-19"/>
+  </releases>
   <categories>
     <category>Education</category>
     <category>Literature</category>

--- a/com.elsevier.MendeleyDesktop.json
+++ b/com.elsevier.MendeleyDesktop.json
@@ -73,17 +73,17 @@
                     "type": "extra-data",
                     "filename": "mendeley.tar.bz2",
                     "only-arches": ["x86_64"],
-                    "url": "https://desktop-download.mendeley.com/download/linux/mendeleydesktop-1.19.1-linux-x86_64.tar.bz2",
-                    "sha256": "6c6db49952fda5bcda59d6dd2f38467687494cca90473485f3630e672cc8cbe7",
-                    "size": 159305572
+                    "url": "https://desktop-download.mendeley.com/download/linux/mendeleydesktop-1.19.2-linux-x86_64.tar.bz2",
+                    "sha256": "7a8dfcae08cb3218ada0b4ba333906c0f5dc5cfc8c9bf11f7f73194018af5a7f",
+                    "size": 159146426
                 },
                 {
                     "type": "extra-data",
                     "filename": "mendeley.tar.bz2",
                     "only-arches": ["i386"],
-                    "url": "https://desktop-download.mendeley.com/download/linux/mendeleydesktop-1.19.1-linux-i486.tar.bz2",
-                    "sha256": "075b70ed2503b78fa20a44be2e56071f38f9258434337e9d362f620f208f9a9f",
-                    "size": 155368594
+                    "url": "https://desktop-download.mendeley.com/download/linux/mendeleydesktop-1.19.2-linux-i486.tar.bz2",
+                    "sha256": "0669c713e495d82456450be0a3ad53fbb0631ae4c28e9a97fa1f84fd5dd06b7b",
+                    "size": 155393374
                 }
             ]
         }

--- a/com.elsevier.MendeleyDesktop.json
+++ b/com.elsevier.MendeleyDesktop.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.elsevier.MendeleyDesktop",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.9",
+    "runtime-version": "5.11",
     "sdk": "org.kde.Sdk",
     "branch": "stable",
     "command": "mendeleydesktop",
@@ -29,6 +29,7 @@
                 "*.la",
                 "*.a"],
     "modules": [
+        "shared-modules/udev/udev-175.json",
         {
             "name": "mendeley",
             "buildsystem": "simple",
@@ -72,17 +73,17 @@
                     "type": "extra-data",
                     "filename": "mendeley.tar.bz2",
                     "only-arches": ["x86_64"],
-                    "url": "https://desktop-download.mendeley.com/download/linux/mendeleydesktop-1.17.13-linux-x86_64.tar.bz2",
-                    "sha256": "d0f7d129562880026c8d5d0c4016787a208d72e879ccd9496b4ff393c408b091",
-                    "size": 126266490
+                    "url": "https://desktop-download.mendeley.com/download/linux/mendeleydesktop-1.19.1-linux-x86_64.tar.bz2",
+                    "sha256": "6c6db49952fda5bcda59d6dd2f38467687494cca90473485f3630e672cc8cbe7",
+                    "size": 159305572
                 },
                 {
                     "type": "extra-data",
                     "filename": "mendeley.tar.bz2",
                     "only-arches": ["i386"],
-                    "url": "https://desktop-download.mendeley.com/download/linux/mendeleydesktop-1.17.13-linux-i486.tar.bz2",
-                    "sha256": "fede3b1fd2eb87701d8c88a1e9e9a6ab5ec9caf9a31244259684865868e56350",
-                    "size": 131684415
+                    "url": "https://desktop-download.mendeley.com/download/linux/mendeleydesktop-1.19.1-linux-i486.tar.bz2",
+                    "sha256": "075b70ed2503b78fa20a44be2e56071f38f9258434337e9d362f620f208f9a9f",
+                    "size": 155368594
                 }
             ]
         }

--- a/mendeleydesktop
+++ b/mendeleydesktop
@@ -9,6 +9,5 @@ export MENDELEY_BUNDLED_SSL_LIB=/app/extra/lib/ssl
 export MENDELEY_LIB=/app/extra/lib
 export SCRIPT=/app/extra/bin/mendeleydesktop 
 export MENDELEY_BUNDLED_QT_PLUGIN_PATH=/app/extra/lib/mendeleydesktop/plugins
-export LD_LIBRARY_PATH=/usr/lib:/app/extra/lib/ssl:/app/extra/lib:/app/extra/lib/qt:/app/extra
-
+export LD_LIBRARY_PATH=/app/extra/lib/ssl:/app/extra/lib:/app/extra/lib/qt:/app/extra:/usr/lib
 /app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.x86_64 $@


### PR DESCRIPTION
This upgrades to KDE 5.11 and the upstream 1.19.1 release.