### PR TITLE
Don't leave opened shell process after executing app

### DIFF
--- a/mendeleydesktop
+++ b/mendeleydesktop
@@ -9,4 +9,9 @@ export MENDELEY_LIB=/app/extra/lib
 export SCRIPT=/app/extra/bin/mendeleydesktop 
 export MENDELEY_BUNDLED_QT_PLUGIN_PATH=/app/extra/lib/mendeleydesktop/plugins
 export LD_LIBRARY_PATH=/app/extra/lib/ssl:/app/extra/lib/qt:/app/extra/lib:/app/lib
-exec /app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.x86_64 $@
+
+if [ -e /app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.i486 ]; then
+  exec /app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.i486 "$@"
+else
+  exec /app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.x86_64 "$@"
+fi

--- a/mendeleydesktop
+++ b/mendeleydesktop
@@ -1,6 +1,5 @@
 #!/bin/sh
 export MENDELEY_BASE=/app/extra
-export MENDELEY_BIN=/app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.x86_64
 export MENDELEY_BUNDLED_CPP_LIB=/app/extra/lib/cpp
 export MENDELEY_BUNDLED_QT_LIBRARY=/app/extra/lib/qt
 export MENDELEY_BUNDLED_QT_PLUGIN=/app/extra/lib/mendeleydesktop/plugins
@@ -11,7 +10,9 @@ export MENDELEY_BUNDLED_QT_PLUGIN_PATH=/app/extra/lib/mendeleydesktop/plugins
 export LD_LIBRARY_PATH=/app/extra/lib/ssl:/app/extra/lib/qt:/app/extra/lib:/app/lib
 
 if [ -e /app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.i486 ]; then
+  export MENDELEY_BIN=/app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.i486
   exec /app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.i486 "$@"
 else
+  export MENDELEY_BIN=/app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.x86_64
   exec /app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.x86_64 "$@"
 fi

--- a/mendeleydesktop
+++ b/mendeleydesktop
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 export MENDELEY_BASE=/app/extra
 export MENDELEY_BIN=/app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.x86_64
 export MENDELEY_BUNDLED_CPP_LIB=/app/extra/lib/cpp
@@ -9,5 +8,5 @@ export MENDELEY_BUNDLED_SSL_LIB=/app/extra/lib/ssl
 export MENDELEY_LIB=/app/extra/lib
 export SCRIPT=/app/extra/bin/mendeleydesktop 
 export MENDELEY_BUNDLED_QT_PLUGIN_PATH=/app/extra/lib/mendeleydesktop/plugins
-export LD_LIBRARY_PATH=/app/extra/lib/ssl:/app/extra/lib:/app/extra/lib/qt:/app/extra:/usr/lib
-/app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.x86_64 $@
+export LD_LIBRARY_PATH=/app/extra/lib/ssl:/app/extra/lib/qt:/app/extra/lib:/app/lib
+exec /app/extra/lib/mendeleydesktop/libexec/mendeleydesktop.x86_64 $@


### PR DESCRIPTION
* Using 'exec' will prevent leaving opened shell process.

* Rationalize LD_LIBRARY_PATH env variable
According to wiki[1] the default is LD_LIBRARY_PATH=/app/lib. This change prepends needed library directories to default value. /usr/lib and /app/extra aren't needed here.

[1] https://github.com/flatpak/flatpak/wiki/Sandbox