### PR TITLE
Remove unnecessary permissions

### DIFF
--- a/com.elsevier.MendeleyDesktop.json
+++ b/com.elsevier.MendeleyDesktop.json
@@ -11,9 +11,7 @@
         "--share=ipc",
         "--share=network",
         "--socket=x11",
-        "--socket=pulseaudio",
         "--device=dri",
-        "--device=all",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--filesystem=home"


### PR DESCRIPTION
AFAIK this app can't play audio/video on its own - it only offers opening them in external apps thus --socket=pulseaudio and --device=all permissions are unnecessary.