### PR TITLE
Move to freedekstop 18.08 runtime

### DIFF
--- a/com.elsevier.MendeleyDesktop.json
+++ b/com.elsevier.MendeleyDesktop.json
@@ -1,8 +1,8 @@
 {
     "app-id": "com.elsevier.MendeleyDesktop",
-    "runtime": "org.kde.Platform",
-    "runtime-version": "5.11",
-    "sdk": "org.kde.Sdk",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "18.08",
+    "sdk": "org.freedesktop.Sdk",
     "branch": "stable",
     "command": "mendeleydesktop",
     "separate-locales": false,


### PR DESCRIPTION
We use bundled qt so having it in runtime is redundant and bloated. This didn't work before but some changes in fdo 18.08 fixed it.