### PR TITLE
Allow hosts /tmp access

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In order to use LibreOffice plugin, please do the following steps:
 
 * Install it
 
-* **Note**: Inserting bibligraphy may not work correctly, see https://github.com/flathub/com.elsevier.MendeleyDesktop/issues/22
+* **Note**: If using LibreOffice from flatpak, you have to allow it to access /tmp from host, i.e. `flatpak override --filesystem=/tmp org.libreoffice.LibreOffice`
 
 Reference:
 https://blog.kukuh.syafaat.id/2018/LibreOffice-and-Mendeley-Desktop-Flatpak/

--- a/com.elsevier.MendeleyDesktop.json
+++ b/com.elsevier.MendeleyDesktop.json
@@ -13,7 +13,8 @@
         "--device=dri",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
-        "--filesystem=home"
+        "--filesystem=home",
+        "--filesystem=/tmp"
     ],
     "cleanup": ["/include",
                 "/lib/pkgconfig",


### PR DESCRIPTION
/tmp is used while inserting Bibliography from LibreOfficie plugin. As both Mendeley and LO have to access same files, we have to use hosts /tmp instead of /tmp inside sandbox.

Fixes #22