### PR TITLE
Revert "Update mendeleydesktop.deb to 1.19.4"

### DIFF
--- a/com.elsevier.MendeleyDesktop.appdata.xml
+++ b/com.elsevier.MendeleyDesktop.appdata.xml
@@ -23,6 +23,8 @@
   </screenshots>
   <releases>
     <release version="1.19.4" date="2019-04-08"/>
+    <release date="2019-05-02" version="1.19.5"/>
+    <release date="2019-04-08" version="1.19.4"/>
     <release date="2018-11-28" version="1.19.3"/>
     <release date="2018-08-13" version="1.19.2"/>
     <release date="2018-07-04" version="1.19.1"/>

--- a/com.elsevier.MendeleyDesktop.appdata.xml
+++ b/com.elsevier.MendeleyDesktop.appdata.xml
@@ -22,12 +22,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release date="2019-05-02" version="1.19.5"/>
-    <release date="2019-04-08" version="1.19.4"/>
-    <release date="2018-11-28" version="1.19.3"/>
-    <release date="2018-08-13" version="1.19.2"/>
-    <release date="2018-07-04" version="1.19.1"/>
-    <release date="2017-12-19" version="1.17.13"/>
+    <release version="1.19.5" date="2019-05-02"/>
   </releases>
   <categories>
     <category>Education</category>

--- a/com.elsevier.MendeleyDesktop.appdata.xml
+++ b/com.elsevier.MendeleyDesktop.appdata.xml
@@ -22,7 +22,6 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.19.4" date="2019-04-08"/>
     <release date="2019-05-02" version="1.19.5"/>
     <release date="2019-04-08" version="1.19.4"/>
     <release date="2018-11-28" version="1.19.3"/>

--- a/com.elsevier.MendeleyDesktop.json
+++ b/com.elsevier.MendeleyDesktop.json
@@ -72,14 +72,7 @@
                     "only-arches": ["x86_64"],
                     "url": "https://desktop-download.mendeley.com/download/apt/pool/main/m/mendeleydesktop/mendeleydesktop_1.19.5-stable_amd64.deb",
                     "sha256": "3e07fc5e98d096815fe470b2812051634b9ea1c30b8c7f9254f6c7df01c64fb1",
-                    "size": 124074630,
-                    "x-checker-data": {
-                        "type": "debian-repo",
-                        "package-name": "mendeleydesktop",
-                        "root": "https://desktop-download.mendeley.com/download/apt",
-                        "dist": "stable",
-                        "component": "main"
-                    }
+                    "size": 124074630
                 }
             ]
         }

--- a/com.elsevier.MendeleyDesktop.json
+++ b/com.elsevier.MendeleyDesktop.json
@@ -5,7 +5,9 @@
     "sdk": "org.freedesktop.Sdk",
     "command": "mendeleydesktop",
     "separate-locales": false,
-    "tags": ["proprietary"],
+    "tags": [
+        "proprietary"
+    ],
     "finish-args": [
         "--share=ipc",
         "--share=network",
@@ -16,16 +18,18 @@
         "--filesystem=home",
         "--filesystem=/tmp"
     ],
-    "cleanup": ["/include",
-                "/lib/pkgconfig",
-                "/share/pkgconfig",
-                "/share/aclocal",
-                "/man",
-                "/share/man",
-                "/share/gtk-doc",
-                "/share/doc",
-                "*.la",
-                "*.a"],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/man",
+        "/share/gtk-doc",
+        "/share/doc",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name": "mendeley",
@@ -69,7 +73,9 @@
                 {
                     "type": "extra-data",
                     "filename": "mendeleydesktop.deb",
-                    "only-arches": ["x86_64"],
+                    "only-arches": [
+                        "x86_64"
+                    ],
                     "url": "https://desktop-download.mendeley.com/download/apt/pool/main/m/mendeleydesktop/mendeleydesktop_1.19.5-stable_amd64.deb",
                     "sha256": "3e07fc5e98d096815fe470b2812051634b9ea1c30b8c7f9254f6c7df01c64fb1",
                     "size": 124074630

--- a/com.elsevier.MendeleyDesktop.json
+++ b/com.elsevier.MendeleyDesktop.json
@@ -5,9 +5,7 @@
     "sdk": "org.freedesktop.Sdk",
     "command": "mendeleydesktop",
     "separate-locales": false,
-    "tags": [
-        "proprietary"
-    ],
+    "tags": ["proprietary"],
     "finish-args": [
         "--share=ipc",
         "--share=network",
@@ -18,18 +16,16 @@
         "--filesystem=home",
         "--filesystem=/tmp"
     ],
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/share/pkgconfig",
-        "/share/aclocal",
-        "/man",
-        "/share/man",
-        "/share/gtk-doc",
-        "/share/doc",
-        "*.la",
-        "*.a"
-    ],
+    "cleanup": ["/include",
+                "/lib/pkgconfig",
+                "/share/pkgconfig",
+                "/share/aclocal",
+                "/man",
+                "/share/man",
+                "/share/gtk-doc",
+                "/share/doc",
+                "*.la",
+                "*.a"],
     "modules": [
         {
             "name": "mendeley",
@@ -73,12 +69,10 @@
                 {
                     "type": "extra-data",
                     "filename": "mendeleydesktop.deb",
-                    "only-arches": [
-                        "x86_64"
-                    ],
-                    "url": "https://desktop-download.mendeley.com/download/apt/pool/main/m/mendeleydesktop/mendeleydesktop_1.19.4-stable_amd64.deb",
-                    "sha256": "7ec9e38360f38065667dcd8b8bd350e70438780f83fca03bd5a11a3d3304cae4",
-                    "size": 123820898,
+                    "only-arches": ["x86_64"],
+                    "url": "https://desktop-download.mendeley.com/download/apt/pool/main/m/mendeleydesktop/mendeleydesktop_1.19.5-stable_amd64.deb",
+                    "sha256": "3e07fc5e98d096815fe470b2812051634b9ea1c30b8c7f9254f6c7df01c64fb1",
+                    "size": 124074630,
                     "x-checker-data": {
                         "type": "debian-repo",
                         "package-name": "mendeleydesktop",


### PR DESCRIPTION
Reverts flathub/com.elsevier.MendeleyDesktop#29

Release notes claims1.19.5 is a stable version: https://www.mendeley.com/release-notes

I don't know why they failed to update links on website.