### PR TITLE
Revert "Update runtime to 22.08"

### DIFF
--- a/com.elsevier.MendeleyDesktop.json
+++ b/com.elsevier.MendeleyDesktop.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.elsevier.MendeleyDesktop",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "mendeleydesktop",
     "separate-locales": false,


### PR DESCRIPTION
Reverts flathub/com.elsevier.MendeleyDesktop#50

Fixes https://github.com/flathub/com.elsevier.MendeleyDesktop/issues/51